### PR TITLE
feat: add android static shared class that's can be used for locking state on native side

### DIFF
--- a/android/src/main/java/com/orientationturbo/OrientationTurbo.kt
+++ b/android/src/main/java/com/orientationturbo/OrientationTurbo.kt
@@ -1,0 +1,82 @@
+package com.orientationturbo
+
+import android.annotation.SuppressLint
+import android.app.Activity
+import android.content.pm.ActivityInfo
+import com.orientationturbo.enums.LandscapeDirection
+import com.orientationturbo.enums.Orientation
+
+/**
+ * OrientationTurbo - Shared state manager for orientation control
+ * For native integration with Activity
+ * Can be used before React Native loads and syncs with OrientationTurboModule
+ */
+object OrientationTurbo {
+
+  @JvmStatic
+  var sharedState: OrientationState? = null
+    private set
+
+  data class OrientationState(
+    val orientation: Orientation,
+    val isLocked: Boolean
+  )
+
+  /**
+   * Locks the device to portrait orientation
+   */
+  @SuppressLint("SourceLockedOrientationActivity")
+  @JvmStatic
+  fun lockToPortrait(activity: Activity, direction: String? = null) {
+    when (direction) {
+      "UPSIDE_DOWN" -> {
+        activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
+        sharedState = OrientationState(Orientation.PORTRAIT, true)
+      }
+      else -> {
+        activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        sharedState = OrientationState(Orientation.PORTRAIT, true)
+      }
+    }
+  }
+
+  /**
+   * Locks the device to landscape orientation
+   */
+  @JvmStatic
+  fun lockToLandscape(activity: Activity, direction: String) {
+    when (direction) {
+      LandscapeDirection.LEFT.value -> {
+        activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+        sharedState = OrientationState(Orientation.LANDSCAPE_LEFT, true)
+      }
+      LandscapeDirection.RIGHT.value -> {
+        activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
+        sharedState = OrientationState(Orientation.LANDSCAPE_RIGHT, true)
+      }
+      else -> {
+        activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+        sharedState = OrientationState(Orientation.LANDSCAPE_LEFT, true)
+      }
+    }
+  }
+
+  /**
+   * Unlocks all orientations, allowing the device to rotate freely
+   */
+  @JvmStatic
+  fun unlockAllOrientations(activity: Activity) {
+    activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+    sharedState = OrientationState(Orientation.PORTRAIT, false)
+  }
+
+  @JvmStatic
+  internal fun clearSharedState() {
+    sharedState = null
+  }
+
+  @JvmStatic
+  internal fun updateSharedState(orientation: Orientation, isLocked: Boolean) {
+    sharedState = OrientationState(orientation, isLocked)
+  }
+}

--- a/android/src/main/java/com/orientationturbo/OrientationTurboModule.kt
+++ b/android/src/main/java/com/orientationturbo/OrientationTurboModule.kt
@@ -24,6 +24,19 @@ class OrientationTurboModule(private val reactContext: ReactApplicationContext) 
   private var orientationEventListener: OrientationEventListener? = null
   private var isOrientationTrackingEnabled = false
 
+  init {
+    if (OrientationTurbo.sharedState != null) { 
+      syncWithSharedState()
+    }
+  }
+
+  private fun syncWithSharedState() {
+    OrientationTurbo.sharedState?.let { sharedState ->
+      currentLockedOrientation = sharedState.orientation
+      isOrientationLocked = sharedState.isLocked
+      OrientationTurbo.clearSharedState()
+    }
+  }
 
   private fun emitOnOrientationChange() {
     val eventData = Arguments.createMap().apply {

--- a/example/android/app/src/main/java/orientationturbo/example/MainActivity.kt
+++ b/example/android/app/src/main/java/orientationturbo/example/MainActivity.kt
@@ -1,9 +1,11 @@
 package orientationturbo.example
 
+import android.os.Bundle
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
 import com.facebook.react.defaults.DefaultReactActivityDelegate
+import com.orientationturbo.OrientationTurbo
 
 class MainActivity : ReactActivity() {
 
@@ -12,6 +14,13 @@ class MainActivity : ReactActivity() {
    * rendering of the component.
    */
   override fun getMainComponentName(): String = "OrientationTurboExample"
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    // Static class to call before OrientationTurboModule is instantiated
+    // This lock state will be synced with OrientationTurboModule after app is run
+    OrientationTurbo.lockToPortrait(this)
+    super.onCreate(savedInstanceState)
+  }
 
   /**
    * Returns the instance of the [ReactActivityDelegate]. We use [DefaultReactActivityDelegate]

--- a/example/ios/OrientationTurboExample/AppDelegate.swift
+++ b/example/ios/OrientationTurboExample/AppDelegate.swift
@@ -23,6 +23,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     reactNativeFactory = factory
 
     window = UIWindow(frame: UIScreen.main.bounds)
+    
+    // This locks orientation before react native is booted
+    OrientationTurboImpl.shared.lockToPortrait()
 
     factory.startReactNative(
       withModuleName: "OrientationTurboExample",


### PR DESCRIPTION
1. OrientationTurbo static class that can be used on MainActivity was created
2. `syncWithSharedState` on OrientationTurboModule would be called in `init` to sync shared state from MainActivity
3. `./example` is updated with showing IOS and Android locking on native side before react native is booted. Mainly for locking before bootsplash screen