### PR TITLE
feat: implement manifest sync for orientation lock state

### DIFF
--- a/android/src/main/java/com/orientationturbo/OrientationTurbo.kt
+++ b/android/src/main/java/com/orientationturbo/OrientationTurbo.kt
@@ -27,30 +27,22 @@ object OrientationTurbo {
    */
   @SuppressLint("SourceLockedOrientationActivity")
   @JvmStatic
-  fun lockToPortrait(activity: Activity, direction: String? = null) {
-    when (direction) {
-      "UPSIDE_DOWN" -> {
-        activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
-        sharedState = OrientationState(Orientation.PORTRAIT, true)
-      }
-      else -> {
-        activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        sharedState = OrientationState(Orientation.PORTRAIT, true)
-      }
-    }
+  fun lockToPortrait(activity: Activity) {
+    activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    sharedState = OrientationState(Orientation.PORTRAIT, true)
   }
 
   /**
    * Locks the device to landscape orientation
    */
   @JvmStatic
-  fun lockToLandscape(activity: Activity, direction: String) {
+  fun lockToLandscape(activity: Activity, direction: LandscapeDirection) {
     when (direction) {
-      LandscapeDirection.LEFT.value -> {
+      LandscapeDirection.LEFT -> {
         activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
         sharedState = OrientationState(Orientation.LANDSCAPE_LEFT, true)
       }
-      LandscapeDirection.RIGHT.value -> {
+      LandscapeDirection.RIGHT -> {
         activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
         sharedState = OrientationState(Orientation.LANDSCAPE_RIGHT, true)
       }

--- a/android/src/main/java/com/orientationturbo/OrientationTurboModule.kt
+++ b/android/src/main/java/com/orientationturbo/OrientationTurboModule.kt
@@ -9,6 +9,7 @@ import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.module.annotations.ReactModule
 import com.orientationturbo.enums.LandscapeDirection
 import com.orientationturbo.enums.Orientation
+import com.orientationturbo.utils.OrientationSync
 
 @ReactModule(name = OrientationTurboModule.NAME)
 class OrientationTurboModule(private val reactContext: ReactApplicationContext) :
@@ -25,16 +26,9 @@ class OrientationTurboModule(private val reactContext: ReactApplicationContext) 
   private var isOrientationTrackingEnabled = false
 
   init {
-    if (OrientationTurbo.sharedState != null) { 
-      syncWithSharedState()
-    }
-  }
-
-  private fun syncWithSharedState() {
-    OrientationTurbo.sharedState?.let { sharedState ->
-      currentLockedOrientation = sharedState.orientation
-      isOrientationLocked = sharedState.isLocked
-      OrientationTurbo.clearSharedState()
+    OrientationSync.getInitialOrientationState(reactContext).let { state ->
+      currentLockedOrientation = state.orientation
+      isOrientationLocked = state.isLocked
     }
   }
 

--- a/android/src/main/java/com/orientationturbo/utils/OrientationSync.kt
+++ b/android/src/main/java/com/orientationturbo/utils/OrientationSync.kt
@@ -1,0 +1,83 @@
+package com.orientationturbo.utils
+
+import android.content.pm.ActivityInfo
+import android.content.pm.PackageManager
+import com.facebook.react.bridge.ReactApplicationContext
+import com.orientationturbo.OrientationTurbo
+import com.orientationturbo.enums.Orientation
+
+/**
+ * Sync functions for orientation configuration and state management
+ */
+object OrientationSync {
+
+  data class OrientationState(
+    val orientation: Orientation,
+    val isLocked: Boolean
+  )
+
+  private fun syncWithSharedState(): OrientationState? {
+    return OrientationTurbo.sharedState?.let { sharedState ->
+      OrientationTurbo.clearSharedState()
+      OrientationState(
+        orientation = sharedState.orientation,
+        isLocked = sharedState.isLocked
+      )
+    }
+  }
+
+  private fun syncWithManifestConfiguration(reactContext: ReactApplicationContext): OrientationState {
+    return try {
+      val activity = reactContext.currentActivity
+      if (activity != null) {
+        val packageManager = reactContext.packageManager
+        val componentName = activity.componentName
+        val activityInfo = packageManager.getActivityInfo(componentName, PackageManager.GET_META_DATA)
+
+        when (activityInfo.screenOrientation) {
+          ActivityInfo.SCREEN_ORIENTATION_PORTRAIT -> {
+            OrientationState(Orientation.PORTRAIT, true)
+          }
+          ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT -> {
+            OrientationState(Orientation.PORTRAIT, true)
+          }
+          ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE -> {
+            OrientationState(Orientation.LANDSCAPE_LEFT, true)
+          }
+          ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE -> {
+            OrientationState(Orientation.LANDSCAPE_RIGHT, true)
+          }
+          ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT -> {
+            OrientationState(Orientation.PORTRAIT, true)
+          }
+          ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE -> {
+            OrientationState(Orientation.LANDSCAPE_LEFT, true)
+          }
+          ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED,
+          ActivityInfo.SCREEN_ORIENTATION_SENSOR,
+          ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR,
+          ActivityInfo.SCREEN_ORIENTATION_USER -> {
+            OrientationState(Orientation.PORTRAIT, false)
+          }
+          else -> {
+            OrientationState(Orientation.PORTRAIT, false)
+          }
+        }
+      } else {
+        OrientationState(Orientation.PORTRAIT, false)
+      }
+    } catch (e: Exception) {
+      OrientationState(Orientation.PORTRAIT, false)
+    }
+  }
+
+  fun getInitialOrientationState(reactContext: ReactApplicationContext): OrientationState {
+    if (OrientationTurbo.sharedState != null) {
+      syncWithSharedState()?.let { sharedState ->
+        return sharedState
+      }
+    }
+
+    return syncWithManifestConfiguration(reactContext)
+  }
+}


### PR DESCRIPTION
1. `OrientationSync` is a utility functions that's defines priority sync from `AndroidManifest` and from `MainActivity`
2. `OrientationTurboModule` is running `getInitialOrientationState` on `init` to get state from `AndroidManifest` or from `MainActivity`