### PR TITLE
fix: issue 5 ios null lock state control

### DIFF
--- a/ios/OrientationTurbo.mm
+++ b/ios/OrientationTurbo.mm
@@ -31,7 +31,7 @@ RCT_EXPORT_MODULE()
   BOOL isLocked = [[OrientationTurboImpl shared] isLocked];
   
   NSDictionary *eventData = @{
-    @"orientation": currentOrientation,
+    @"orientation": isLocked ? currentOrientation : [NSNull null],
     @"isLocked": @(isLocked)
   };
   

--- a/ios/OrientationTurboImpl.swift
+++ b/ios/OrientationTurboImpl.swift
@@ -99,16 +99,6 @@ public class OrientationTurboImpl: NSObject {
   
   @objc public func unlockAllOrientations() {
     updateLockState(locked: false, orientation: nil)
-    
-    // First rotate to portrait, then unlock all orientations after a brief delay.
-    // Workaround to keep PORTRAIT back to default
-    requestOrientationChange(.portrait) { [weak self] success in
-      if success {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-          self?.requestOrientationChange(.all)
-        }
-      }
-    }
   }
   
   @objc public func getCurrentOrientation() -> String {


### PR DESCRIPTION
1. IOS `onLockOrientationChange` returns null for `orientation` it it's not locked
2. Fix `unlockAllOrientation` call (was not working correctly)